### PR TITLE
Refactor MidiFile, beef up CLI

### DIFF
--- a/mellowchord/__init__.py
+++ b/mellowchord/__init__.py
@@ -19,4 +19,10 @@ from .mellowchord import KeyedChord  # noqa: F401
 from .mellowchord import chords_types_are_equal  # noqa: F401
 from .mellowchord import ChordParseError  # noqa: F401
 from .mellowchord import MidiFile  # noqa: F401
+from .mellowchord import make_file_name_from_chord_sequence  # noqa: F401
+from .mellowchord import chordgen  # noqa: F401
+from .mellowchord import validate_key  # noqa: F401
+from .mellowchord import validate_start  # noqa: F401
+from .mellowchord import InvalidArgumentError  # noqa: F401
+from .mellowchord import MellowchordError  # noqa: F401
 from .cli import main  # noqa: F401

--- a/mellowchord/cli.py
+++ b/mellowchord/cli.py
@@ -1,14 +1,26 @@
 import argparse
-from mellowchord import ChordMap
+from mellowchord import chordgen
+from mellowchord import MellowchordError
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Generate a series of chord sequences')
-    parser.add_argument('key', type=str, help='key')
-    parser.add_argument('start', type=str, help='name of the chord to start from')
-    parser.add_argument('num', type=int, help='number of chords in each sequence')
+    parser = argparse.ArgumentParser(description='Tool for generating chord sequences and melodies as MIDI files')
+    subparsers = parser.add_subparsers(dest='command')
+
+    chordgen_parser = subparsers.add_parser('chordgen', aliases=['c'], help='Generate a series of chord sequences')
+    chordgen_parser.add_argument('key', type=str, help='key (all keys are major)')
+    chordgen_parser.add_argument('start', type=str, help='name of the chord to start from')
+    chordgen_parser.add_argument('num', type=int, help='number of chords in each sequence')
+
+    melodygen_parser = subparsers.add_parser('melodygen',
+                                             aliases=['m'],
+                                             help='Generate a melody to match a chord sequence')
 
     args = parser.parse_args()
-    cm = ChordMap(args.key)
-    for seq in cm.gen_sequence(args.start, args.num):
-        print(seq)
+    try:
+        if args.command in ('chordgen', 'c'):
+            chordgen(args.key, args.start, args.num)
+        elif args.command in ('melodygen', 'm'):
+            print('not implemented!')
+    except MellowchordError as e:
+        print(e)

--- a/mellowchord/tests/test_mellowchord.py
+++ b/mellowchord/tests/test_mellowchord.py
@@ -13,6 +13,10 @@ from mellowchord import IVM, IVM_1
 from mellowchord import VM, VM_1
 from mellowchord import vim
 from mellowchord import MidiFile
+from mellowchord import make_file_name_from_chord_sequence
+from mellowchord import validate_key
+from mellowchord import validate_start
+from mellowchord import MellowchordError
 import musthe
 import pytest
 
@@ -72,12 +76,36 @@ def test_keyed_chord():
 def test_keyed_chord_midi():
     midi_file = MidiFile('test.mid')
     kc1 = KeyedChord('C', Chord(1, 'maj'))
-    kc1.add_to_midi_file(midi_file)
+    midi_file.add_chord(kc1)
     kc4 = KeyedChord('C', Chord(4, 'maj'))
-    kc4.add_to_midi_file(midi_file)
+    midi_file.add_chord(kc4)
     kc5 = KeyedChord('C', Chord(5, 'maj'))
-    kc5.add_to_midi_file(midi_file)
+    midi_file.add_chord(kc5)
     midi_file.write()
+
+
+def test_make_file_name_from_chord_sequence():
+    kc1 = KeyedChord('C', Chord(1, 'maj'))
+    kc4 = KeyedChord('C', Chord(4, 'maj'))
+    kc5 = KeyedChord('C', Chord(5, 'maj'))
+    assert make_file_name_from_chord_sequence([kc1, kc4, kc5]) == 'Cmaj_Fmaj_Gmaj'
+
+
+def test_validate_key():
+    validate_key('C')
+    validate_key('D#')
+    validate_key('Bb')
+    with pytest.raises(MellowchordError):
+        validate_key('foo')
+
+
+def test_validate_start():
+    cm = ChordMap('C')
+    validate_start('Cmaj', cm)
+    with pytest.raises(MellowchordError):
+        validate_start('Dmaj', cm)
+    with pytest.raises(MellowchordError):
+        validate_start('foo', cm)
 
 
 def test_map():
@@ -149,9 +177,9 @@ def test_gen_sequence():
     cm = ChordMap('C')
     for seq in cm.gen_sequence('Cmaj', 3):
         assert len(seq) == 3
-        assert seq[0] == 'Cmaj'
-        assert seq[1] in ('Fmaj/C', 'Gmaj/C')
-        assert seq[2] in ('Cmaj', 'Cmaj7')
+        assert str(seq[0]) == 'Cmaj'
+        assert str(seq[1]) in ('Fmaj/C', 'Gmaj/C')
+        assert str(seq[2]) in ('Cmaj', 'Cmaj7')
 
 
 def test_split_bass():

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
     packages=find_packages(),
     entry_points={
         'console_scripts': [
+            'mc=mellowchord:main',
             'mellowchord=mellowchord:main',
         ],
     },


### PR DESCRIPTION
MidiFile was refactored:

- New add_chord method on MidiFile instead of the old method on KeyedChord
- MidiFile:add_chord was refactored a lot to reduce redundant code

The CLI has subcommands now for chordgen and melodygen.  Lot of new functions:
- make_file_name_from_chord_sequence
- chordgen
- validate_key
- validate_start
added to make CLI more robust and easier to write code for.

ChordMap:gen_sequence now yields list of KeyedChord instead of list of strings