### PR TITLE
Change bass to inversion and implement transposition

### DIFF
--- a/mellowchord/__init__.py
+++ b/mellowchord/__init__.py
@@ -1,3 +1,4 @@
+from .mellowchord import apply_inversion  # noqa: F401
 from .mellowchord import _split_bass  # noqa: F401
 from .mellowchord import string_to_chord  # noqa: F401
 from .mellowchord import string_to_keyed_chord  # noqa: F401
@@ -14,7 +15,7 @@ from .mellowchord import IVM  # noqa: F401
 from .mellowchord import IVM_1  # noqa: F401
 from .mellowchord import vim  # noqa: F401
 from .mellowchord import VM  # noqa: F401
-from .mellowchord import VM_1  # noqa: F401
+from .mellowchord import VM_2  # noqa: F401
 from .mellowchord import KeyedChord  # noqa: F401
 from .mellowchord import chords_types_are_equal  # noqa: F401
 from .mellowchord import ChordParseError  # noqa: F401


### PR DESCRIPTION
I previously interpreted slash chords in the map as bass notes two octaves down.  I now treat it in the more accepted way of an inverted chord.  You specify first inversion or second inversion rather than bass note.  This allowed me to implement chord transposition in the CLI.