### PR TITLE
Add generated melodies to MIDI

### DIFF
--- a/mellowchord/__init__.py
+++ b/mellowchord/__init__.py
@@ -30,6 +30,7 @@ from .mellowchord import chords_types_are_equal  # noqa: F401
 from .mellowchord import ChordParseError  # noqa: F401
 from .mellowchord import MidiFile  # noqa: F401
 from .mellowchord import make_file_name_from_chord_sequence  # noqa: F401
+from .mellowchord import make_file_name_from_melody  # noqa: F401
 from .mellowchord import validate_key  # noqa: F401
 from .mellowchord import validate_start  # noqa: F401
 from .mellowchord import InvalidArgumentError  # noqa: F401
@@ -37,4 +38,5 @@ from .mellowchord import MellowchordError  # noqa: F401
 from .mellowchord import write_chord_sequence_json  # noqa: F401
 from .mellowchord import read_chord_sequence_json  # noqa: F401
 from .mellowchord import MelodyGenerator  # noqa: F401
+from .mellowchord import write_midi_file  # noqa: F401
 from .cli import main  # noqa: F401

--- a/mellowchord/tests/test_chord.py
+++ b/mellowchord/tests/test_chord.py
@@ -103,5 +103,4 @@ def test_keyed_chord_midi():
     # Assert that there's only one ALL_SOUNDS_OFF at the end
     mido_file = mido.MidiFile('test.mid')
     assert mido_file.tracks[0][-1] == mido.MetaMessage('end_of_track')
-    assert mido_file.tracks[0][-2] == MidiFile.ALL_SOUNDS_OFF
-    assert mido_file.tracks[0][-3] != MidiFile.ALL_SOUNDS_OFF
+    assert mido_file.tracks[0][-2] != MidiFile.ALL_SOUNDS_OFF


### PR DESCRIPTION
Lots of other little changes in this commit:

- ChordMap now takes an octave adjustment which the CLI uses to lower chords an octave by default.  This might be a controllable option in the future.
- write_midi_file takes a melody (a sequence of notes) as a new input.
- When choosing a chord in the interactive CLI you now use one-based numbers instead of zero-based numbers.
- Fixed a small bug where doing an inversion via the interactive CLI would not update the names of the MIDI and JSON files like it should.
- Implement midi and play commands for melodygen.
- Add function to MidiFile that accepts chord sequence and melody at the same time.
- Fixed bug where sevenths were not getting octave adjusted like they should be.
- Update various test code.